### PR TITLE
Press4-471 | For consistency, we should use dashes instead of underscores for API endpoints

### DIFF
--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-i18n'), 'version' => '025d61ab5c962a6374ed');
+<?php return array('dependencies' => array('react', 'wp-api-fetch', 'wp-components', 'wp-i18n'), 'version' => '8f289c9855d55f58da62');

--- a/includes/Facebook.php
+++ b/includes/Facebook.php
@@ -1,7 +1,6 @@
 <?php
 namespace NewfoldLabs\WP\Module\Facebook;
 
-use NewfoldLabs\WP\Module\Data\Helpers\Encryption;
 use NewfoldLabs\WP\ModuleLoader\Container;
 
 /**

--- a/includes/RestApi/FacebookController.php
+++ b/includes/RestApi/FacebookController.php
@@ -51,7 +51,7 @@ class FacebookController
 
         register_rest_route(
             $this->namespace,
-            $this->rest_base . '/fb_token',
+            $this->rest_base . '/get-token',
             array(
                 array(
                     'methods' => \WP_REST_Server::CREATABLE,
@@ -63,7 +63,7 @@ class FacebookController
 
         register_rest_route(
             $this->namespace,
-            $this->rest_base . '/fb_token',
+            $this->rest_base . '/post-token',
             array(
                 array(
                     'methods' => \WP_REST_Server::READABLE,

--- a/includes/Services/FacebookHelperService.php
+++ b/includes/Services/FacebookHelperService.php
@@ -41,7 +41,7 @@ class FacebookHelperService
 
     public static function get_fb_business($result, $FacebookData, $fb_token)
     {
-        $business_url = NFD_FACEBOOK_GRAPH_BASE . '/me/accounts?fields=category%2Ccategory_list%2Cname%2Cid%2Ctasks&access_token=' . $fb_token . '&format=json';
+        $business_url = NFD_FACEBOOK_GRAPH_BASE . '/me/accounts?fields=category%2Ccategory_list%2Cname%2Cid%2Ctasks%2Cpicture&access_token=' . $fb_token . '&format=json';
         $business_results = wp_remote_get(
             $business_url,
             array(
@@ -54,6 +54,7 @@ class FacebookHelperService
         $business_response = json_decode(wp_remote_retrieve_body($business_results));
 
         if ($business_response && $business_response->data) {
+            UtilityService::upload_file_by_url($business_response->data[0]->picture->data->url);
             $FacebookData->get_business()->set_profile($business_response->data);
         }
     }

--- a/includes/Services/FacebookHelperService.php
+++ b/includes/Services/FacebookHelperService.php
@@ -41,7 +41,7 @@ class FacebookHelperService
 
     public static function get_fb_business($result, $FacebookData, $fb_token)
     {
-        $business_url = NFD_FACEBOOK_GRAPH_BASE . '/me/accounts?fields=category%2Ccategory_list%2Cname%2Cid%2Ctasks%2Cpicture&access_token=' . $fb_token . '&format=json';
+        $business_url = NFD_FACEBOOK_GRAPH_BASE . '/me/accounts?fields=category%2Ccategory_list%2Cname%2Cid%2Ctasks&access_token=' . $fb_token . '&format=json';
         $business_results = wp_remote_get(
             $business_url,
             array(

--- a/includes/Services/FacebookHelperService.php
+++ b/includes/Services/FacebookHelperService.php
@@ -54,7 +54,6 @@ class FacebookHelperService
         $business_response = json_decode(wp_remote_retrieve_body($business_results));
 
         if ($business_response && $business_response->data) {
-            UtilityService::upload_file_by_url($business_response->data[0]->picture->data->url);
             $FacebookData->get_business()->set_profile($business_response->data);
         }
     }

--- a/includes/Services/UtilityService.php
+++ b/includes/Services/UtilityService.php
@@ -89,8 +89,9 @@ class UtilityService
         $existing_attachment = attachment_url_to_postid($image_url);
 
         if(!$existing_attachment){
-            $media_id = media_sideload_image($image_url, 0);
-            set_theme_mod('custom_logo', $media_id);
+            $media_id = media_sideload_image($image_url, 0, null, 'src');
+            $existing_attachment = attachment_url_to_postid($media_id);
+            set_theme_mod('custom_logo', $existing_attachment);
         }
 
     }

--- a/includes/Services/UtilityService.php
+++ b/includes/Services/UtilityService.php
@@ -3,6 +3,11 @@ namespace NewfoldLabs\WP\Module\Facebook\Services;
 
 use NewfoldLabs\WP\Module\Data\Helpers\Encryption;
 
+
+require_once(ABSPATH . 'wp-admin/includes/image.php');
+require_once(ABSPATH . 'wp-admin/includes/file.php');
+require_once(ABSPATH . 'wp-admin/includes/media.php');
+
 class UtilityService
 {
     public static function dateDiffInDays($date)
@@ -78,5 +83,15 @@ class UtilityService
     public static function deleteTokenFromCookie()
     {
         setcookie('fb_access_token', '', time() - (MONTH_IN_SECONDS * 2));
+    }
+
+    public static function upload_file_by_url( $image_url ) {
+        $existing_attachment = attachment_url_to_postid($image_url);
+
+        if(!$existing_attachment){
+            $media_id = media_sideload_image($image_url, 0);
+            set_theme_mod('custom_logo', $media_id);
+        }
+
     }
 }

--- a/includes/Services/UtilityService.php
+++ b/includes/Services/UtilityService.php
@@ -85,15 +85,4 @@ class UtilityService
         setcookie('fb_access_token', '', time() - (MONTH_IN_SECONDS * 2));
     }
 
-    public static function upload_file_by_url( $image_url ) {
-        $existing_attachment = attachment_url_to_postid($image_url);
-
-        if(!$existing_attachment){
-            $media_id = media_sideload_image($image_url, 0, null, 'src');
-            // set logo 
-            // $existing_attachment = attachment_url_to_postid($media_id);
-            // set_theme_mod('custom_logo', $existing_attachment);
-        }
-
-    }
 }

--- a/includes/Services/UtilityService.php
+++ b/includes/Services/UtilityService.php
@@ -90,8 +90,9 @@ class UtilityService
 
         if(!$existing_attachment){
             $media_id = media_sideload_image($image_url, 0, null, 'src');
-            $existing_attachment = attachment_url_to_postid($media_id);
-            set_theme_mod('custom_logo', $existing_attachment);
+            // set logo 
+            // $existing_attachment = attachment_url_to_postid($media_id);
+            // set_theme_mod('custom_logo', $existing_attachment);
         }
 
     }

--- a/includes/Services/UtilityService.php
+++ b/includes/Services/UtilityService.php
@@ -3,11 +3,6 @@ namespace NewfoldLabs\WP\Module\Facebook\Services;
 
 use NewfoldLabs\WP\Module\Data\Helpers\Encryption;
 
-
-require_once(ABSPATH . 'wp-admin/includes/image.php');
-require_once(ABSPATH . 'wp-admin/includes/file.php');
-require_once(ABSPATH . 'wp-admin/includes/media.php');
-
 class UtilityService
 {
     public static function dateDiffInDays($date)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -9,7 +9,10 @@ export default {
   wordpress: {
     access: NewfoldRuntime.createApiUrl('/newfold-facebook/v1/facebook/hiive'),
     fb_token: NewfoldRuntime.createApiUrl(
-      '/newfold-facebook/v1/facebook/fb_token'
+      '/newfold-facebook/v1/facebook/get-token'
+    ),
+    post_token: NewfoldRuntime.createApiUrl(
+      '/newfold-facebook/v1/facebook/post-token'
     ),
     facebook_details: NewfoldRuntime.createApiUrl(
       '/newfold-facebook/v1/facebook/details'


### PR DESCRIPTION
For consistency, we should use dashes instead of underscores for API endpoints

Jira Link: https://jira.newfold.com/browse/PRESS4-471