### PR TITLE
Improve Error Handling for `FacebookConnectButton`

### DIFF
--- a/includes/RestApi/FacebookController.php
+++ b/includes/RestApi/FacebookController.php
@@ -110,13 +110,13 @@ class FacebookController
             );
         }
         if ( is_string( $fb_details ) && preg_match( '/^token not found!$/', $fb_details ) ) {
-            return new \WP_REST_Response(
-                array(
-                    'status' => 'error',
-                    'details' => 'You are not authorized'
-                ),
-                401
-            );
+			return new \WP_Error(
+				'nfd_module_facebook_error',
+				__( 'Token not found.', 'wp-module-facebook' ),
+				array(
+					'status' => 404,
+				),
+			);
         }
         else {
             return new \WP_REST_Response(

--- a/includes/RestApi/FacebookController.php
+++ b/includes/RestApi/FacebookController.php
@@ -112,7 +112,7 @@ class FacebookController
         if ( is_string( $fb_details ) && preg_match( '/^token not found!$/', $fb_details ) ) {
 			return new \WP_Error(
 				'nfd_module_facebook_error',
-				__( 'Token not found.', 'wp-module-facebook' ),
+				__( 'Details not found.', 'wp-module-facebook' ),
 				array(
 					'status' => 404,
 				),

--- a/src/components/facebookConnectButton.js
+++ b/src/components/facebookConnectButton.js
@@ -54,7 +54,6 @@ const FacebookConnectButton = ({
             if (typeof onFailure === 'function') {
               onFailure(err);
             }
-            console.error(err);
           });
         setFieldValue(res.token);
       })
@@ -63,7 +62,6 @@ const FacebookConnectButton = ({
         if (typeof onFailure === 'function') {
           onFailure(err);
         }
-        console.error(err);
       });
 
   const getProfileData = () => {

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -41,7 +41,7 @@ export const getFacebookUserProfileDetails = () => {
       return res?.details;
     })
     .catch((error) => {
-      throw { message: 'failed to load the data', errorMsg: error };
+      throw error;
     });
 };
 


### PR DESCRIPTION
## Proposed changes

1. Return standard error object as an argument to the `onFailure` function.
2. Remove `console.error`'s.

This goes with: https://github.com/newfold-labs/wp-module-onboarding/pull/571

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
