### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,4 +36,4 @@ composer run test
 
 ## Keeping documentation current
 
-When you change code, features, or workflows, update the docs. When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.
+When you change code, features, or workflows, update the docs. Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present). When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent guidance – wp-module-facebook
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-facebook** – Module connects to customers' Facebook profile and fetches data. Registers with the Newfold Module Loader; depends on wp-module-data and wp-module-loader. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.3+. See docs/dependencies.md.
+
+- **Architecture:** Registers with the loader; provides Facebook integration. See docs/integration.md.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Bootstrap | `bootstrap.php` |
+| Includes | `includes/` |
+| Tests | `tests/` |
+
+## Essential commands
+
+```bash
+composer install
+composer run lint
+composer run fix
+composer run test
+```
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+When you change code, features, or workflows, update the docs. When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-facebook
+title: Dependencies
+description: Composer and npm dependencies.
+updated: 2025-03-18
+---
+
 # Dependencies
 
 **Runtime:** newfold-labs/wp-module-data, newfold-labs/wp-module-loader. **Dev:** newfold-labs/wp-php-standards, wp-cli/i18n-command, johnpbloch/wordpress, lucatume/wp-browser, phpunit/phpcov.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,3 @@
+# Dependencies
+
+**Runtime:** newfold-labs/wp-module-data, newfold-labs/wp-module-loader. **Dev:** newfold-labs/wp-php-standards, wp-cli/i18n-command, johnpbloch/wordpress, lucatume/wp-browser, phpunit/phpcov.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,3 @@
+# Development
+
+PHP: `composer run lint`, `composer run fix`. Tests: `composer run test`. When changing dependencies, update [dependencies.md](dependencies.md). When cutting a release, update **docs/changelog.md**.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-facebook
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 PHP: `composer run lint`, `composer run fix`. Tests: `composer run test`. When changing dependencies, update [dependencies.md](dependencies.md). When cutting a release, update **docs/changelog.md**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,12 @@
+# Getting started
+
+Prerequisites: PHP 7.3+, Composer. The module requires wp-module-data, wp-module-loader.
+
+```bash
+composer install
+composer run test
+composer run lint
+composer run fix
+```
+
+See [integration.md](integration.md) for using in a host plugin.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-facebook
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 Prerequisites: PHP 7.3+, Composer. The module requires wp-module-data, wp-module-loader.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,5 +7,6 @@
 | [integration.md](integration.md) | How the module registers and how hosts use it. |
 | [development.md](development.md) | Lint, test, and workflow. |
 | [dependencies.md](dependencies.md) | Composer dependencies. |
+| [release.md](release.md) | Release process: use the Newfold Prepare Release workflow. |
 
 Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# wp-module-facebook – Documentation index
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does and who maintains it. |
+| [getting-started.md](getting-started.md) | Prerequisites, install, and tests. |
+| [integration.md](integration.md) | How the module registers and how hosts use it. |
+| [development.md](development.md) | Lint, test, and workflow. |
+| [dependencies.md](dependencies.md) | Composer dependencies. |
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-facebook
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-facebook – Documentation index
 
 | Document | Description |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-facebook
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 The module registers with the Newfold Module Loader via bootstrap.php. The host plugin typically registers a Facebook service for onboarding or other flows. See [dependencies.md](dependencies.md).

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,3 @@
+# Integration
+
+The module registers with the Newfold Module Loader via bootstrap.php. The host plugin typically registers a Facebook service for onboarding or other flows. See [dependencies.md](dependencies.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+**wp-module-facebook** connects to customers' Facebook profiles and fetches data for Newfold brand plugins. It registers with the Newfold Module Loader and depends on wp-module-data and wp-module-loader. Maintained by Newfold Labs. Distributed via Newfold Satis.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-facebook
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 **wp-module-facebook** connects to customers' Facebook profiles and fetches data for Newfold brand plugins. It registers with the Newfold Module Loader and depends on wp-module-data and wp-module-loader. Maintained by Newfold Labs. Distributed via Newfold Satis.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,26 @@
+# Release process
+
+This module follows the standard Newfold release process using a reusable workflow.
+
+## Prepare release (recommended)
+
+1. **Run the Newfold Prepare Release workflow**
+   - In GitHub: **Actions** → **Newfold Prepare Release** → **Run workflow**.
+   - Choose the version **level**: `patch`, `minor`, or `major`.
+   - The workflow will:
+     - Bump the version to the chosen level (in the appropriate files, e.g. `composer.json`, plugin header, or `package.json`).
+     - Run a fresh build if the module has frontend assets.
+     - Update language files (i18n).
+     - Open a pull request with the changes.
+
+2. **Review and merge** the prep-release PR.
+
+3. **Tag and publish** the release (e.g. create a GitHub release from the tag, or follow your team's process for Satis/packagist).
+
+## Manual release (fallback)
+
+If the workflow is unavailable, bump the version manually in the same places the workflow would (see `.github/workflows/newfold-prep-release.yml` inputs for `json-file` and `php-file`), run any build and i18n commands, then tag and release. Prefer using the workflow when possible for consistency.
+
+## After each release
+
+- Update **docs/changelog.md** with the changes in the release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,21 @@
+---
+name: wp-module-facebook
+title: Release process
+description: Release process and version bump.
+updated: 2025-03-18
+---
+
 # Release process
 
 This module follows the standard Newfold release process using a reusable workflow.
+
+## Build step required
+
+See `.github/workflows/newfold-prep-release.yml`: the workflow uses `json-file` and `php-file` inputs. If this module has a frontend (e.g. `package.json` has a `build` script), run `npm run build` before tagging; the workflow runs it automatically. Otherwise no build step is required.
+
+## Hardcoded versions to bump
+
+The workflow bumps the version in the files specified in `.github/workflows/newfold-prep-release.yml` (`json-file` and `php-file`—typically **bootstrap.php** for the PHP version constant (e.g. `NFD_*_MODULE_VERSION`) and **package.json** for the `version` field). If releasing manually, update those files, run any build and i18n commands, then tag and release.
 
 ## Prepare release (recommended)
 


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, and dependencies where applicable.

Made with [Cursor](https://cursor.com)