### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,10 +19,10 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
-    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write      # Required because the reusable workflow pushes the auto-translate branch to this repository.
       pull-requests: write # Required because the reusable workflow uses `gh pr` to list, update, and create pull requests.
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     timeout-minutes: 120
     with:
       text_domain: 'wp-module-facebook'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required because the reusable workflow pushes the auto-translate branch to this repository.
       pull-requests: write # Required because the reusable workflow uses `gh pr` to list, update, and create pull requests.
+    timeout-minutes: 120
     with:
       text_domain: 'wp-module-facebook'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required because the reusable workflow pushes the auto-translate branch to this repository.
+      pull-requests: write # Required because the reusable workflow uses `gh pr` to list, update, and create pull requests.
     with:
       text_domain: 'wp-module-facebook'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # Derives the branch name from GITHUB_HEAD_REF/GITHUB_REF only; no checkout and no GITHUB_TOKEN usage.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone this private module and the brand plugin with GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for the reusable workflow to clone this private module and the brand plugin with GITHUB_TOKEN.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -32,9 +32,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this private module and the brand plugin with GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
@@ -45,9 +45,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this private module and the brand plugin with GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Derives the branch name from GITHUB_HEAD_REF/GITHUB_REF only; no checkout and no GITHUB_TOKEN usage.
+    timeout-minutes: 10
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this private module and the brand plugin with GITHUB_TOKEN.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for the reusable workflow to clone this private module and the brand plugin with GITHUB_TOKEN.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # Sets outputs from github.repository only; no checkout and no GITHUB_TOKEN API calls.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write       # Required for the reusable workflow to push coverage HTML to gh-pages using secrets.GITHUB_TOKEN (repo_token).
+      pull-requests: write # Required for the reusable workflow to add or update pull request comments for coverage results.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Sets outputs from github.repository only; no checkout and no GITHUB_TOKEN API calls.
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write       # Required for the reusable workflow to push coverage HTML to gh-pages using secrets.GITHUB_TOKEN (repo_token).
       pull-requests: write # Required for the reusable workflow to add or update pull request comments for coverage results.
+    timeout-minutes: 50
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -31,10 +31,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write       # Required for the reusable workflow to push coverage HTML to gh-pages using secrets.GITHUB_TOKEN (repo_token).
       pull-requests: write # Required for the reusable workflow to add or update pull request comments for coverage results.
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     timeout-minutes: 50
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,15 +8,18 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: read # Required so the reusable Crowdin download job can run actions/checkout against this private repository; Crowdin PR creation uses secrets.NEWFOLD_ACCESS_TOKEN inside the reusable workflow.
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      NEWFOLD_ACCESS_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Required so the reusable Crowdin download job can run actions/checkout against this private repository; Crowdin PR creation uses secrets.NEWFOLD_ACCESS_TOKEN inside the reusable workflow.
+    timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -14,9 +14,9 @@ permissions: {}
 
 jobs:
   call-crowdin-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     permissions:
       contents: read # Required so the reusable Crowdin download job can run actions/checkout against this private repository; Crowdin PR creation uses secrets.NEWFOLD_ACCESS_TOKEN inside the reusable workflow.
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     timeout-minutes: 30
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -9,9 +9,9 @@ permissions: {}
 
 jobs:
   call-crowdin-upload-workflow:
-    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Required so the reusable Crowdin upload job can run actions/checkout against this private repository with GITHUB_TOKEN.
+    uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: read # Required so the reusable Crowdin upload job can run actions/checkout against this private repository with GITHUB_TOKEN.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -12,6 +12,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     permissions:
       contents: read # Required so the reusable Crowdin upload job can run actions/checkout against this private repository with GITHUB_TOKEN.
+    timeout-minutes: 30
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -9,10 +9,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required for actions/checkout to clone this private repository.
+      pull-requests: read # Required so technote-space/get-diff-action can read the pull request diff via GITHUB_TOKEN.
     steps:
 
       - name: Checkout repository

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read       # Required for actions/checkout to clone this private repository.
       pull-requests: read # Required so technote-space/get-diff-action can read the pull request diff via GITHUB_TOKEN.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout repository

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
       contents: write      # Required for the reusable workflow to push the release branch to this module repository.
       pull-requests: write # Required for the reusable workflow to open the draft release pull request with `gh pr create`.
+    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     timeout-minutes: 35
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for the reusable workflow to push the release branch to this module repository.
+      pull-requests: write # Required for the reusable workflow to open the draft release pull request with `gh pr create`.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push the release branch to this module repository.
       pull-requests: write # Required for the reusable workflow to open the draft release pull request with `gh pr create`.
+    timeout-minutes: 35
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read   # Required to clone this private repository via actions/checkout.
       id-token: write # Required for npm Trusted Publishing through OIDC to registry.npmjs.org.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Node 24+ required: trusted publishing (OIDC) needs npm 11.5.1+; Node 22 ships npm 10

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,12 +5,16 @@ on:
       - created
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      contents: read   # Required to clone this private repository via actions/checkout.
+      id-token: write # Required for npm Trusted Publishing through OIDC to registry.npmjs.org.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Node 24+ required: trusted publishing (OIDC) needs npm 11.5.1+; Node 22 ships npm 10

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read       # Required to clone this private repository via actions/checkout.
       packages: write      # Required so npm publish to GitHub Packages can authenticate via NODE_AUTH_TOKEN (GITHUB_TOKEN).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Registry

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,9 +3,17 @@ on:
   release:
     types:
       - created
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # Required to clone this private repository via actions/checkout.
+      packages: write      # Required so npm publish to GitHub Packages can authenticate via NODE_AUTH_TOKEN (GITHUB_TOKEN).
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Registry

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # peter-evans/repository-dispatch authenticates with secrets.WEBHOOK_TOKEN only; GITHUB_TOKEN is unused.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # peter-evans/repository-dispatch authenticates with secrets.WEBHOOK_TOKEN only; GITHUB_TOKEN is unused.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 10 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint-php.yml`, `newfold-prep-release.yml`, `npm-publish.yml`, `publish-package.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `d0bb40f` |
| Timeouts commit | `bc2d156` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `auto-translate.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `npm-publish.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `publish-package.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| publish-package.yml | 1 job was missing a scoped `permissions:` directive | publish | `contents: read`, `packages: write` [3] |
| lint-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read`, `pull-requests: read` [2] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: read` [3] |
| i18n-crowdin-download.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-workflow | `contents: read` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `auto-translate.yml` :: `translate`: BEFORE `permissions` block placed before `uses` and without per-permission trailing comments -> AFTER `uses` then `permissions` with `contents: write` / `pull-requests: write` and comments -- matches audit placement rules and-documents why the reusable translations workflow needs write access to the caller repo -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- job only derives a branch name from environment variables and never checks out the repository or calls the GitHub API with `GITHUB_TOKEN` -- [3] |
| 3 | `brand-plugin-test-playwright.yml` :: `bluehost` / `bluehost-dev`: BEFORE `contents: read` without inline rationale -> AFTER same scope with comments; `permissions` placed immediately after `uses` -- documents why the reusable Playwright workflow needs read access to clone private repos -- [3] |
| 4 | `codecoverage-main.yml` :: workflow root: BEFORE `contents: read` -> AFTER required default-deny `{}` with the standard comment block -- least privilege at workflow level; reusable job retains explicit write scopes -- [3] |
| 5 | `codecoverage-main.yml` :: `codecoverage`: BEFORE `permissions` keyed before `uses` and without trailing comments -> AFTER `uses` then `permissions` with `contents: write` / `pull-requests: write` comments -- aligns with audit placement and explains `repo_token` / PR comment behavior in `newfold-labs/workflows` reusable code coverage -- [3] |
| 6 | `i18n-crowdin-download.yml` :: workflow root: BEFORE `contents: write`, `pull-requests: write` -> AFTER `{}` with the standard comments -- the reusable Crowdin download workflow sets `GITHUB_TOKEN` to `secrets.NEWFOLD_ACCESS_TOKEN` for write operations and only needs read on the caller token for checkout per that reusable’s job defaults -- [3] |
| 7 | `newfold-prep-release.yml` :: `prep-release`: BEFORE `permissions` before `uses` without trailing comments -> AFTER `uses` then `permissions` with comments -- aligns with reusable module prep release (`gh pr`, branch push) rationale -- [3] |
| 8 | `npm-publish.yml` :: `build`: BEFORE `contents: read`, `id-token: write` without inline comments -> AFTER same scopes with trailing comments -- documents checkout vs npm OIDC publishing requirements without widening scopes -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `30` | several short shell/output steps plus an external repository-dispatch POST; thirty minutes caps waste if the runner or endpoint misbehaves. |
| publish-package.yml | publish | `30` | checkout plus `npm ci` and a single-package publish ordinarily finishes well under half an hour. |
| npm-publish.yml | build | `45` | dependency install, build script, and npm OIDC trusted publish merit a modest buffer above typical quick publishes. |
| lint-php.yml | phpcs | `30` | Composer install and targeted PHPCS runs on changed files should complete within this window except under severe infra issues. |
| codecoverage-main.yml | get-repo-name | `5` | single-step metadata extraction completes almost instantly. |
| codecoverage-main.yml | codecoverage | `50` | callers must outlive `newfold-labs/workflows` reusable coverage jobs (configured up to forty-five minutes internally). |
| brand-plugin-test-playwright.yml | setup | `10` | branch extraction only. |
| — | — | — | `brand-plugin-test-playwright.yml` :: `bluehost` / `bluehost-dev` -> `60` -- each invokes the reusable Playwright module/plugin test workflow capped at forty-five minutes; extra margin avoids the caller timing out first. |
| auto-translate.yml | translate | `120` | chains multiple reusable translation jobs (prepare, translate, process, PR) whose internal timeouts can sum close to ninety minutes in worst cases. |
| newfold-prep-release.yml | prep-release | `35` | reusable prep-release sets a twenty-minute internal cap; this leaves headroom for queueing and GitHub scheduling variance. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `30` | reusable Crowdin upload times out at fifteen minutes; caller bound stays safely above that. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `30` | reusable Crowdin download times out at twenty minutes; same rationale. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `lint-php.yml` :: `pull-requests: read` for `technote-space/get-diff-action` is based on that action’s use of `github.token` to resolve PR file diffs; if future runs show permission errors, re-check the action’s current documentation for any extra scopes (for example `contents: read` alone might suffice on some configurations) -- [2] |
| 2 | `i18n-crowdin-download.yml` now maps `NEWFOLD_ACCESS_TOKEN` into the reusable workflow `secrets` block as required by `newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main`; confirm the repository defines that secret (and that the PAT has the expected `repo` scope) or the workflow will still fail at runtime -- [3] |


